### PR TITLE
Stress test 3.14vsM_PI fix

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 
 int main() {
-    long double pi = mc_pi(30000);
+    long double pi = mc_pi(100000000);
     printf("pi: %.10Lf\n", pi);
     return 0;
 }

--- a/tests/mc_pi_test.cpp
+++ b/tests/mc_pi_test.cpp
@@ -16,8 +16,8 @@ TEST(mc_pi, stress) {
     long double deviation;
     for (int i = 6; i < 10; i++) {
         pi = mc_pi((int)pow(10, i));
-        deviation = abs(pi - 3.14);
-        ASSERT_LT(deviation, 0.025);
+        deviation = abs(pi - M_PI);
+        ASSERT_LT(deviation, 0.0015);
     }
 }
 


### PR DESCRIPTION
1) Replacing 3.14 compare with M_PI compare in stress test
2) Replacing v_count in demonstration for higher accuracy